### PR TITLE
Out-Of-Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+stxxl.errlog
+stxxl.log
 cachegrind.out.*
 core
 *.o

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 	rm -f *.o
 
 cleaner: clean
-	rm -f viewshed_test dem_test sort_test
+	rm -f viewshed_test dem_test sort_test stxxl.errlog stxxl.log
 
 cleanest: cleaner
 	rm -f cachegrind.out.*

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,13 @@ GDAL_CFLAGS ?= -I$(HOME)/local/gdal/include
 GDAL_LDFLAGS ?= -L$(HOME)/local/gdal/lib -lgdal -lopenjp2
 PDAL_CXXFLAGS ?= -I$(HOME)/local/pdal/include
 PDAL_LDFLAGS ?= -L$(HOME)/local/pdal/lib -lpdalcpp -llaszip
+STXXL_CXXFLAGS ?= -I$(HOME)/local/stxxl/include
+STXXL_LDFLAGS ?= -L$(HOME)/local/stxxl/lib -lpthread -lstxxl
 OPENCL_LDFLAGS ?= -lOpenCL
 CFLAGS ?= -Wall -march=native -mtune=native -Ofast -g
 CXXFLAGS ?= -Wall -march=native -mtune=native -Ofast -g
 CFLAGS += -std=c11 $(GDAL_CFLAGS)
-CXXFLAGS += -std=c++11 $(PDAL_CXXFLAGS)
+CXXFLAGS += -std=c++11
 
 
 all: viewshed_test dem_test
@@ -15,7 +17,7 @@ viewshed_test: viewshed_test.o rasterio.o opencl.o viewshed.o
 	$(CC) $^ $(GDAL_LDFLAGS) $(OPENCL_LDFLAGS) -o $@
 
 dem_test: dem_test.o pdal.o opencl.o
-	$(CC) $^ $(PDAL_LDFLAGS) $(OPENCL_LDFLAGS) -lstdc++ -o $@
+	$(CC) $^ $(PDAL_LDFLAGS) $(OPENCL_LDFLAGS) $(STXXL_LDFLAGS) -lstdc++ -o $@
 
 sort_test: sort_test.o opencl.o bitonic.o partition.o
 	$(CC) $^ $(OPENCL_LDFLAGS) -lstdc++ -o $@
@@ -28,6 +30,9 @@ sort_test: sort_test.o opencl.o bitonic.o partition.o
 
 %.o: %.cpp %.h Makefile
 	$(CXX) $(CXXFLAGS) $< -c -o $@
+
+pdal.o: pdal.cpp pdal.h Makefile
+	$(CXX) $(CXXFLAGS) $< $(PDAL_CXXFLAGS) $(STXXL_CXXFLAGS) -c -o $@
 
 %o: %.cpp Makefile
 	$(CXX) $(CXXFLAGS) $< -c -o $@

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ sort_test: sort_test.o opencl.o bitonic.o partition.o
 	$(CXX) $(CXXFLAGS) $< -c -o $@
 
 pdal.o: pdal.cpp pdal.h Makefile
-	$(CXX) $(CXXFLAGS) $< $(PDAL_CXXFLAGS) $(STXXL_CXXFLAGS) -c -o $@
+	$(CXX) -Wno-unknown-pragmas -Wno-terminate $(CXXFLAGS) $< $(PDAL_CXXFLAGS) $(STXXL_CXXFLAGS) -c -o $@
 
 %o: %.cpp Makefile
 	$(CXX) $(CXXFLAGS) $< -c -o $@

--- a/dem_test.c
+++ b/dem_test.c
@@ -80,7 +80,7 @@ int main(int argc, char ** argv)
    * OUTPUT *
    **********/
   fprintf(stderr, "wkt = %s\n", projection);
-  fprintf(stderr, "%lf %lf %lf %lf %lf %lf\n",
+  fprintf(stderr, "transform = %lf %lf %lf %lf %lf %lf\n",
           transform[0], transform[1], transform[2],
           transform[3], transform[4], transform[5]);
 

--- a/pdal.cpp
+++ b/pdal.cpp
@@ -37,6 +37,7 @@
 #include <pdal/io/LasReader.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
+#include <stxxl/vector>
 #include "pdal.h"
 
 
@@ -54,6 +55,7 @@ void pdal_load(const char * filename,
   PointTable table;
   PointViewPtr view;
   PointViewSet set;
+  stxxl::vector<double[3]> v;
 
   options.add("filename", filename);
   reader.setOptions(options);

--- a/pdal.cpp
+++ b/pdal.cpp
@@ -37,7 +37,7 @@
 #include <pdal/io/LasReader.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/StageFactory.hpp>
-#include <stxxl/vector>
+#include <stxxl.h>
 #include "pdal.h"
 
 
@@ -55,8 +55,13 @@ void pdal_load(const char * filename,
   PointTable table;
   PointViewPtr view;
   PointViewSet set;
-  stxxl::vector<double[3]> v;
 
+  // STXXL.  Reference: http://stxxl.org/tags/master/install_config.html
+  stxxl::config * cfg = stxxl::config::get_instance();
+  cfg->add_disk( stxxl::disk_config("disk=/tmp/StreetLevel.stxxl, 8 GiB, syscall unlink"));
+  stxxl::VECTOR_GENERATOR<struct pdal_point>::result v;
+
+  // PDAL
   options.add("filename", filename);
   reader.setOptions(options);
   reader.prepare(table);
@@ -87,12 +92,18 @@ void pdal_load(const char * filename,
 
   fprintf(stderr, "pointCount = %ld\n", header.pointCount());
 
-  // for (unsigned int i = 0; i < header.pointCount(); ++i)
-  //   {
-  //     double x, y, z;
-  //     x = view->point(i).getFieldAs<double>(pdal::Dimension::Id::X);
-  //     y = view->point(i).getFieldAs<double>(pdal::Dimension::Id::Y);
-  //     z = view->point(i).getFieldAs<double>(pdal::Dimension::Id::Z);
-  //     fprintf(stderr, "%lf %lf %lf\n", x, y, z);
-  //   }
+  for (unsigned int i = 0; i < header.pointCount(); ++i)
+    {
+      struct pdal_point point;
+      point.x = view->point(i).getFieldAs<double>(pdal::Dimension::Id::X);
+      point.y = view->point(i).getFieldAs<double>(pdal::Dimension::Id::Y);
+      point.z = view->point(i).getFieldAs<double>(pdal::Dimension::Id::Z);
+      v.push_back(point);
+    }
+
+  for (int i = 0; i < 50; ++i)
+    {
+      struct pdal_point point = v[i];
+      fprintf(stdout, "%3d %lf %lf %lf\n", i, point.x, point.y, point.z);
+    }
 }

--- a/pdal.h
+++ b/pdal.h
@@ -34,6 +34,13 @@
 
 #include <stdint.h>
 
+struct pdal_point
+{
+  double x;
+  double y;
+  double z;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
STXXL should had to be build as follows:

```bash
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/local/stxxl -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ ..
```

with the crucial part the explicit specification of the compiler.  cmake
was choosing the system-wide compiler even though the desired one was
before it on the path.