### PR TITLE
Sort

### DIFF
--- a/pdal.cpp
+++ b/pdal.cpp
@@ -91,17 +91,39 @@ void pdal_load(const char * sofilename,
   /***********************************************************************
    * STXXL.  Reference: http://stxxl.org/tags/master/install_config.html *
    ***********************************************************************/
-  // stxxl::config * cfg = stxxl::config::get_instance();
-  // cfg->add_disk( stxxl::disk_config("disk=/tmp/StreetLevel.stxxl, 8 GiB, syscall unlink"));
+  stxxl::config * cfg = stxxl::config::get_instance();
+  cfg->add_disk( stxxl::disk_config("disk=/tmp/StreetLevel.stxxl, 0, syscall unlink"));
   min_point.key = 0;
   max_point.key = 0xffffffffffffffff;
   point_sorter sorter(key_comparator(), (1<<30));
 
-  // XXX
-  x_min = 391800.0000000000;
-  x_max = 392599.9900000000;
-  y_min = 140200.0000000000;
-  y_max = 141799.9900000000;
+  /************************
+   * COMPUTE BOUNDING BOX *
+   ************************/
+  for (int i = 0; i < filenamec; ++i) {
+    DimTypeList dims;
+    LasHeader header;
+    LasReader reader;
+    Options options;
+    PointTable table;
+    PointViewSet set;
+    PointViewPtr view;
+
+    options.add("filename", filenamev[i]);
+    reader.setOptions(options);
+    reader.prepare(table);
+    header = reader.header();
+
+    double h_x_min = header.minX();
+    double h_x_max = header.maxX();
+    double h_y_min = header.minY();
+    double h_y_max = header.maxY();
+
+    if (h_x_min < x_min) x_min = h_x_min;
+    if (h_x_max > x_max) x_max = h_x_max;
+    if (h_y_min < y_min) y_min = h_y_min;
+    if (h_y_max > y_max) y_max = h_y_max;
+  }
   x_range = x_max - x_min;
   y_range = y_max - y_min;
 

--- a/pdal.h
+++ b/pdal.h
@@ -39,7 +39,7 @@ typedef struct pdal_point {
   double y;
   double z;
   uint64_t key;
-} point;
+} pdal_point;
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Hilbert ###

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 8160 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 24171311 μs
x: 391800.0000000000 	392599.9900000000
y: 140200.0000000000 	140999.9900000000
samples: 35077820
[STXXL-ERRMSG] External memory block allocation error: 50331648 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 47239 μs
000002521a63f890 	391800.3600000000 	391800.3599999176 	140200.2100000000 	140200.2099999985
000003967e5d7411 	391800.0800000000 	391800.0799999817 	140200.2000000000 	140200.1999999542
000004d910e3fc24 	391800.0700000000 	391800.0699999374 	140200.5000000000 	140200.4999999787
000005129aba5a7d 	391800.0700000000 	391800.0699999374 	140200.6100000000 	140200.6099999070
000005c2c6574265 	391800.1800000000 	391800.1799998657 	140200.6600000000 	140200.6599999421
000005f39cd45b39 	391800.1500000000 	391800.1499999191 	140200.6000000000 	140200.5999998627
000006fd4f3f90be 	391800.3700000000 	391800.3699999619 	140200.6100000000 	140200.6099999070
00000729eb88eeb0 	391800.3100000000 	391800.3099998825 	140200.5000000000 	140200.4999999787
000008915fcf33ca 	391800.5400000000 	391800.5399999696 	140200.5100000000 	140200.5099998367
000008c225a9399e 	391800.4700000000 	391800.4699998459 	140200.5700000000 	140200.5699999161
000009da92e159f0 	391800.4900000000 	391800.4899999344 	140200.6400000000 	140200.6399998536
00000a17fee9e441 	391800.6600000000 	391800.6599999421 	140200.6100000000 	140200.6099999070
00000b0fa4e0cab6 	391800.7700000000 	391800.7699998704 	140200.5400000000 	140200.5399999696
00000b140c26beb4 	391800.7800000000 	391800.7799999146 	140200.5100000000 	140200.5099998367
00000c970c9b17af 	391800.6600000000 	391800.6599999421 	140200.2100000000 	140200.2099999985
000011f7fb345f67 	391800.9500000000 	391800.9499999223 	140200.2200000000 	140200.2199998565
0000165de22b3109 	391801.5300000000 	391801.5299998827 	140200.2300000000 	140200.2299999008
00001792be87b522 	391801.2500000000 	391801.2499999468 	140200.2200000000 	140200.2199998565
00001872d7d77649 	391801.2500000000 	391801.2499999468 	140200.5200000000 	140200.5199998810
00001916c8f24586 	391801.3900000000 	391801.3899998217 	140200.4800000000 	140200.4799998902
00001988eb966635 	391801.4900000000 	391801.4899998919 	140200.5200000000 	140200.5199998810
000019c74b983872 	391801.4300000000 	391801.4299999988 	140200.5700000000 	140200.5699999161
00001a52667ca36e 	391801.5300000000 	391801.5299998827 	140200.6100000000 	140200.6099999070
00001afca9e110c4 	391801.3800000000 	391801.3799999636 	140200.7700000000 	140200.7699998704
00001b9db9ddc00d 	391801.2400000000 	391801.2399999026 	140200.6200000000 	140200.6199999513
00001cc4c7677732 	391801.1100000000 	391801.1099998857 	140200.5900000000 	140200.5899998184
00001d29457c2bd1 	391801.0800000000 	391801.0799999391 	140200.5100000000 	140200.5099998367
00001dcc1aea46d0 	391801.0200000000 	391801.0199998597 	140200.5100000000 	140200.5099998367
00001f0295834633 	391800.8000000000 	391800.7999998169 	140200.6100000000 	140200.6099999070
00001f5dfac77fe8 	391800.9400000000 	391800.9399998781 	140200.6200000000 	140200.6199999513
000020450745f7b5 	391800.8800000000 	391800.8799999849 	140200.8200000000 	140200.8199999055
00002085c7bcfe62 	391800.8900000000 	391800.8899998429 	140200.9200000000 	140200.9199999757
000020fb8479e2b0 	391800.8100000000 	391800.8099998612 	140200.9700000000 	140200.9699998246
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.195310 0.000000 140200.000000 0.000000 0.195310
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libHilbert2D.so.1.0.1 ~/Downloads/1421.las  33.28s user 3.40s system 144% cpu 25.363 total
```

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 10608 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 43989900 μs
x: 391800.0000000000 	392599.9900000000
y: 140200.0000000000 	141799.9900000000
samples: 65034704
[STXXL-ERRMSG] External memory block allocation error: 471859200 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 360772 μs
0000007c45f24b12 	391800.0800000000 	391800.0799999817 	140200.2000000000 	140200.1999999004
000001937c37fb26 	391800.3600000000 	391800.3599999176 	140200.2100000000 	140200.2099996347
0000027983ddc669 	391800.3100000000 	391800.3099998825 	140200.5000000000 	140200.4999997510
0000029465afd913 	391800.3700000000 	391800.3699999619 	140200.6100000000 	140200.6099998080
0000033079cce564 	391800.1500000000 	391800.1499999191 	140200.6000000000 	140200.5999997012
00000339ef163874 	391800.1800000000 	391800.1799998657 	140200.6600000000 	140200.6599999694
0000038bd01c54d7 	391800.0700000000 	391800.0699999374 	140200.5000000000 	140200.4999997510
000003d33aa013d8 	391800.0700000000 	391800.0699999374 	140200.6100000000 	140200.6099998080
000004677568fd24 	391800.1800000000 	391800.1799998657 	140200.9100000000 	140200.9099996586
000004767b8c27b4 	391800.1300000000 	391800.1299998306 	140200.8900000000 	140200.8899998176
000004dcf9ec2468 	391800.0600000000 	391800.0599998931 	140201.0300000000 	140201.0299998224
000006203fde0053 	391800.2500000000 	391800.2499999893 	140201.2700000000 	140201.2699997774
0000072b7851263f 	391800.3000000000 	391800.2999998382 	140201.0100000000 	140201.0099999814
000007f01308999b 	391800.3900000000 	391800.3899998642 	140200.8700000000 	140200.8699999766
0000081d867ea7d7 	391800.4200000000 	391800.4199999970 	140200.9100000000 	140200.9099996586
000008936a0cc0d9 	391800.5500000000 	391800.5499998276 	140200.9900000000 	140200.9899997678
000009c9be07ce8b 	391800.5500000000 	391800.5499998276 	140201.2800000000 	140201.2799998842
00000b889febc729 	391800.6500000000 	391800.6499998978 	140200.9100000000 	140200.9099996586
00000bb42893fe3f 	391800.6400000000 	391800.6399998536 	140200.8400000000 	140200.8399996562
00000c41a84c217b 	391800.7700000000 	391800.7699998704 	140200.5400000000 	140200.5399998056
00000c4f029ea562 	391800.7800000000 	391800.7799999146 	140200.5100000000 	140200.5099998578
00000cd456512d66 	391800.6600000000 	391800.6599999421 	140200.6100000000 	140200.6099998080
00000d2c092ef209 	391800.4900000000 	391800.4899999344 	140200.6400000000 	140200.6399997558
00000d81d3c09b1f 	391800.4700000000 	391800.4699998459 	140200.5700000000 	140200.5699997534
00000de05bf50a9e 	391800.5400000000 	391800.5399999696 	140200.5100000000 	140200.5099998578
00000f7ce867143b 	391800.6600000000 	391800.6599999421 	140200.2100000000 	140200.2099996347
00001092f109f902 	391800.9500000000 	391800.9499999223 	140200.2200000000 	140200.2199997414
000011433fb98db6 	391800.8000000000 	391800.7999998169 	140200.6100000000 	140200.6099998080
000011b8beb21a7d 	391800.9400000000 	391800.9399998781 	140200.6200000000 	140200.6199999148
0000123516f05f84 	391801.0200000000 	391801.0199998597 	140200.5100000000 	140200.5099998578
00001284f89888f6 	391801.1100000000 	391801.1099998857 	140200.5900000000 	140200.5899999670
000012da43e41a87 	391801.0800000000 	391801.0799999391 	140200.5100000000 	140200.5099998578
0000147d14189bc7 	391801.2500000000 	391801.2499999468 	140200.2200000000 	140200.2199997414
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.195310 0.000000 140200.000000 0.000000 0.390623
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libHilbert2D.so.1.0.1 ~/Downloads/142?.las  59.40s user 5.37s system 142% cpu 45.597 total
```

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 13253 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 67597276 μs
x: 391800.0000000000 	393399.9900000000
y: 140200.0000000000 	141799.9900000000
samples: 97901076
[STXXL-ERRMSG] External memory block allocation error: 448790528 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 371719 μs
0000004535bdf7b7 	391800.0800000000 	391800.0799997366 	140200.2000000000 	140200.1999999004
000000bc8c385422 	391800.3600000000 	391800.3599997463 	140200.2100000000 	140200.2099996347
0000018f418e6688 	391800.6600000000 	391800.6599999694 	140200.2100000000 	140200.2099996347
0000021a2140c773 	391800.4700000000 	391800.4699998032 	140200.5700000000 	140200.5699997534
0000022e57f9617b 	391800.5400000000 	391800.5399998056 	140200.5100000000 	140200.5099998578
00000265a90b05b2 	391800.7800000000 	391800.7799997606 	140200.5100000000 	140200.5099998578
000002694312b27b 	391800.7700000000 	391800.7699996538 	140200.5400000000 	140200.5399998056
0000028f5590dd77 	391800.6600000000 	391800.6599999694 	140200.6100000000 	140200.6099998080
000002dc06325608 	391800.4900000000 	391800.4899996442 	140200.6400000000 	140200.6399997558
0000033f596fcbed 	391800.3700000000 	391800.3699998530 	140200.6100000000 	140200.6099998080
0000034ada489724 	391800.3100000000 	391800.3099999574 	140200.5000000000 	140200.4999997510
000003b4ce9854e8 	391800.0700000000 	391800.0699996299 	140200.5000000000 	140200.4999997510
000003ce0406b14d 	391800.0700000000 	391800.0699996299 	140200.6100000000 	140200.6099998080
000003d4479f4403 	391800.1500000000 	391800.1499997390 	140200.6000000000 	140200.5999997012
000003da3bbf7b9d 	391800.1800000000 	391800.1799996868 	140200.6600000000 	140200.6599999694
000004212635b8e6 	391800.1300000000 	391800.1299998980 	140200.8900000000 	140200.8899998176
0000042c8bc316e7 	391800.1800000000 	391800.1799996868 	140200.9100000000 	140200.9099996586
0000045a99477b2f 	391800.3900000000 	391800.3899996940 	140200.8700000000 	140200.8699999766
00000491219723aa 	391800.3000000000 	391800.2999998506 	140201.0100000000 	140201.0099999814
000004e2ba139282 	391800.0600000000 	391800.0599998956 	140201.0300000000 	140201.0299998224
000005dc056340ef 	391800.2500000000 	391800.2499996892 	140201.2700000000 	140201.2699997774
00000624d6445e75 	391800.5500000000 	391800.5499999124 	140201.2800000000 	140201.2799998842
0000077e2ae5fa25 	391800.5500000000 	391800.5499999124 	140200.9900000000 	140200.9899997678
00000798b5240186 	391800.4200000000 	391800.4199996418 	140200.9100000000 	140200.9099996586
000007c8337c5744 	391800.6400000000 	391800.6399997558 	140200.8400000000 	140200.8399996562
000007ddd1695182 	391800.6500000000 	391800.6499998626 	140200.9100000000 	140200.9099996586
000008164b36dab0 	391800.8100000000 	391800.8099997084 	140200.9700000000 	140200.9699999268
00000823d9c6419d 	391800.8900000000 	391800.8899998176 	140200.9200000000 	140200.9199997654
0000083969dbd43c 	391800.8800000000 	391800.8799997108 	140200.8200000000 	140200.8199998152
00000854de4c0b6c 	391801.1400000000 	391801.1399998793 	140200.7900000000 	140200.7899998674
00000862252bb3d1 	391801.1100000000 	391801.1099999315 	140200.9100000000 	140200.9099996586
00000873688d152b 	391801.0600000000 	391801.0599997702 	140200.9500000000 	140200.9499997132
0000093941045eb5 	391800.8300000000 	391800.8299999220 	140201.2800000000 	140201.2799998842
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.390623 0.000000 140200.000000 0.000000 0.390623
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libHilbert2D.so.1.0.1 ~/Downloads/1?2?.las  90.73s user 6.82s system 140% cpu 1:09.34 total
```

### Morton ###

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 6155 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 18218093 μs
x: 391800.0000000000 	392599.9900000000
y: 140200.0000000000 	140999.9900000000
samples: 35077820
[STXXL-ERRMSG] External memory block allocation error: 50331648 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 45395 μs
0000012894a69bed 	391800.0800000000 	391800.0799999817 	140200.2000000000 	140200.1999999542
000003a32fb2a32f 	391800.3600000000 	391800.3599999176 	140200.2100000000 	140200.2099999985
00000462dfb15438 	391800.0700000000 	391800.0699999374 	140200.5000000000 	140200.4999999787
00000523dfe05069 	391800.0700000000 	391800.0699999374 	140200.6100000000 	140200.6099999070
000005a12497a121 	391800.1500000000 	391800.1499999191 	140200.6000000000 	140200.5999998627
000005bc8ba9bc8a 	391800.1800000000 	391800.1799998657 	140200.6600000000 	140200.6599999421
000006c27d337410 	391800.3100000000 	391800.3099998825 	140200.5000000000 	140200.4999999787
000007a975ead0eb 	391800.3700000000 	391800.3699999619 	140200.6100000000 	140200.6099999070
00000b2907122905 	391800.6600000000 	391800.6599999421 	140200.2100000000 	140200.2099999985
00000c7cc501dee4 	391800.4700000000 	391800.4699998459 	140200.5700000000 	140200.5699999161
00000ce15ab5e14f 	391800.5400000000 	391800.5399999696 	140200.5100000000 	140200.5099998367
00000d901c715da0 	391800.4900000000 	391800.4899999344 	140200.6400000000 	140200.6399998536
00000eebf837ebe7 	391800.7800000000 	391800.7799999146 	140200.5100000000 	140200.5099998367
00000efa07707027 	391800.7700000000 	391800.7699998704 	140200.5400000000 	140200.5399999696
00000f2957427841 	391800.6600000000 	391800.6599999421 	140200.6100000000 	140200.6099999070
000010c8dc687624 	391800.1300000000 	391800.1299998306 	140200.8900000000 	140200.8899998429
000010eccaf8b98e 	391800.1800000000 	391800.1799998657 	140200.9100000000 	140200.9099999315
00001130bc8874fd 	391800.0600000000 	391800.0599998931 	140201.0300000000 	140201.0299999040
000012bfba19bfad 	391800.3900000000 	391800.3899998642 	140200.8700000000 	140200.8699999406
00001384c75b95d5 	391800.3000000000 	391800.2999998382 	140201.0100000000 	140201.0099998155
000016602accae49 	391800.2500000000 	391800.2499999893 	140201.2700000000 	140201.2699998491
0000184c68d0192c 	391800.4200000000 	391800.4199999970 	140200.9100000000 	140200.9099999315
000019a301ec2b88 	391800.5500000000 	391800.5499998276 	140200.9900000000 	140200.9899999132
00001a3079a2ba50 	391800.6400000000 	391800.6399998536 	140200.8400000000 	140200.8399999941
00001a664afa9984 	391800.6500000000 	391800.6499998978 	140200.9100000000 	140200.9099999315
00001ce251ed7e89 	391800.5500000000 	391800.5499998276 	140201.2800000000 	140201.2799998934
000021a6a21b5a46 	391800.9500000000 	391800.9499999223 	140200.2200000000 	140200.2199998565
00002503d5c278e1 	391800.8000000000 	391800.7999998169 	140200.6100000000 	140200.6099999070
000025a650466a83 	391800.9400000000 	391800.9399998781 	140200.6200000000 	140200.6199999513
0000264bd0bf4b6f 	391801.0200000000 	391801.0199998597 	140200.5100000000 	140200.5099998367
000026c17a97c16d 	391801.0800000000 	391801.0799999391 	140200.5100000000 	140200.5099998367
00002788b9b999e3 	391801.1100000000 	391801.1099998857 	140200.5900000000 	140200.5899998184
0000292c2839dacc 	391801.2500000000 	391801.2499999468 	140200.2200000000 	140200.2199998565
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.195310 0.000000 140200.000000 0.000000 0.195310
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libMorton2D.so.1.0.1 ~/Downloads/1421.las  26.70s user 3.38s system 155% cpu 19.373 total
```

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 10542 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 35028375 μs
x: 391800.0000000000 	392599.9900000000
y: 140200.0000000000 	141799.9900000000
samples: 65034704
[STXXL-ERRMSG] External memory block allocation error: 471859200 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 378598 μs
0000006885a38eec 	391800.0800000000 	391800.0799999817 	140200.2000000000 	140200.1999999004
000001329fe45469 	391800.0700000000 	391800.0699999374 	140200.5000000000 	140200.4999997510
00000162dff0116c 	391800.0700000000 	391800.0699999374 	140200.6100000000 	140200.6099998080
000001e06187b574 	391800.1500000000 	391800.1499999191 	140200.6000000000 	140200.5999997012
000001ed8ae8ec9b 	391800.1800000000 	391800.1799998657 	140200.6600000000 	140200.6599999694
000002e26be6a23b 	391800.3600000000 	391800.3599999176 	140200.2100000000 	140200.2099996347
000003923d667441 	391800.3100000000 	391800.3099998825 	140200.5000000000 	140200.4999997510
000003e875fa91ee 	391800.3700000000 	391800.3699999619 	140200.6100000000 	140200.6099998080
00000464ad8834bc 	391800.0600000000 	391800.0599998931 	140201.0300000000 	140201.0299998224
000004989d383624 	391800.1300000000 	391800.1299998306 	140200.8900000000 	140200.8899998176
000004b99abca9cb 	391800.1800000000 	391800.1799998657 	140200.9100000000 	140200.9099996586
000006afee0ceeed 	391800.3900000000 	391800.3899998642 	140200.8700000000 	140200.8699999766
000006c1935ec4d5 	391800.3000000000 	391800.2999998382 	140201.0100000000 	140201.0099999814
000007302a98ff5d 	391800.2500000000 	391800.2499999893 	140201.2700000000 	140201.2699997774
0000093d9140dee5 	391800.4700000000 	391800.4699998459 	140200.5700000000 	140200.5699997534
000009b05ea5f01b 	391800.5400000000 	391800.5399999696 	140200.5100000000 	140200.5099998578
000009c40d345cf1 	391800.4900000000 	391800.4899999344 	140200.6400000000 	140200.6399997558
00000a6843462811 	391800.6600000000 	391800.6599999421 	140200.2100000000 	140200.2099996347
00000b6857523944 	391800.6600000000 	391800.6599999421 	140200.6100000000 	140200.6099998080
00000bbafc27fab3 	391800.7800000000 	391800.7799999146 	140200.5100000000 	140200.5099998578
00000bbe03743162 	391800.7700000000 	391800.7699998704 	140200.5400000000 	140200.5399998056
00000c1938940969 	391800.4200000000 	391800.4199999970 	140200.9100000000 	140200.9099996586
00000ce240f87f9d 	391800.5500000000 	391800.5499998276 	140200.9900000000 	140200.9899997678
00000db214f97bcd 	391800.5500000000 	391800.5499998276 	140201.2800000000 	140201.2799998842
00000e243ce2ab15 	391800.6400000000 	391800.6399998536 	140200.8400000000 	140200.8399996562
00000e331abe89c1 	391800.6500000000 	391800.6499998978 	140200.9100000000 	140200.9099996586
0000101451501544 	391800.0000000000 	391800.0000000000 	140201.7300000000 	140201.7299998463
0000102b62eb3b26 	391800.0900000000 	391800.0899998397 	140201.6000000000 	140201.5999999483
000010910f4308e7 	391800.1000000000 	391800.0999998840 	140201.6900000000 	140201.6899997918
00001129d4e7cebc 	391800.0800000000 	391800.0799999817 	140202.0000000000 	140201.9999997492
000011a52496a561 	391800.1500000000 	391800.1499999191 	140202.0300000000 	140202.0299996969
0000128b55848e51 	391800.3300000000 	391800.3299999710 	140201.6100000000 	140201.6099996826
000012936c237415 	391800.3100000000 	391800.3099998825 	140201.7000000000 	140201.6999998985
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.195310 0.000000 140200.000000 0.000000 0.390623
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libMorton2D.so.1.0.1 ~/Downloads/142?.las  50.98s user 5.22s system 153% cpu 36.721 total
```

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 13002 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 52044802 μs
x: 391800.0000000000 	393399.9900000000
y: 140200.0000000000 	141799.9900000000
samples: 97901076
[STXXL-ERRMSG] External memory block allocation error: 448790528 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 362178 μs
0000004a2529a6e6 	391800.0800000000 	391800.0799997366 	140200.2000000000 	140200.1999999004
000000e8cbeca833 	391800.3600000000 	391800.3599997463 	140200.2100000000 	140200.2099996347
00000118b7ec5443 	391800.0700000000 	391800.0699996299 	140200.5000000000 	140200.4999997510
00000148f7f81146 	391800.0700000000 	391800.0699996299 	140200.6100000000 	140200.6099998080
000001684925b7fe 	391800.1500000000 	391800.1499997390 	140200.6000000000 	140200.5999997012
0000016f22ea6e19 	391800.1800000000 	391800.1799996868 	140200.6600000000 	140200.6599999694
000001b09f4cd6cb 	391800.3100000000 	391800.3099999574 	140200.5000000000 	140200.4999997510
000001ea5d7ab146 	391800.3700000000 	391800.3699998530 	140200.6100000000 	140200.6099998080
000002ca41c48833 	391800.6600000000 	391800.6599999694 	140200.2100000000 	140200.2099996347
0000031f3140766d 	391800.4700000000 	391800.4699998032 	140200.5700000000 	140200.5699997534
0000033856ad7291 	391800.5400000000 	391800.5399998056 	140200.5100000000 	140200.5099998578
00000364071c54f3 	391800.4900000000 	391800.4899996442 	140200.6400000000 	140200.6399997558
000003bafe0dfa13 	391800.7800000000 	391800.7799997606 	140200.5100000000 	140200.5099998578
000003be81dc1362 	391800.7700000000 	391800.7699996538 	140200.5400000000 	140200.5399998056
000003ca55d09966 	391800.6600000000 	391800.6599999694 	140200.6100000000 	140200.6099998080
00000432371a1c84 	391800.1300000000 	391800.1299998980 	140200.8900000000 	140200.8899998176
0000043b32be2b49 	391800.1800000000 	391800.1799996868 	140200.9100000000 	140200.9099996586
0000044c2f221c3c 	391800.0600000000 	391800.0599998956 	140201.0300000000 	140201.0299998224
000004afee866ec5 	391800.3900000000 	391800.3899996940 	140200.8700000000 	140200.8699999766
000004e131d6ceff 	391800.3000000000 	391800.2999998506 	140201.0100000000 	140201.0099999814
000005980ab27f75 	391800.2500000000 	391800.2499996892 	140201.2700000000 	140201.2699997774
000006131a3401cb 	391800.4200000000 	391800.4199996418 	140200.9100000000 	140200.9099996586
00000668c07a5f35 	391800.5500000000 	391800.5499999124 	140200.9900000000 	140200.9899997678
0000068c1e68a9b7 	391800.6400000000 	391800.6399997558 	140200.8400000000 	140200.8399996562
0000069992bea1c3 	391800.6500000000 	391800.6499998626 	140200.9100000000 	140200.9099996586
00000738947b5b65 	391800.5500000000 	391800.5499999124 	140201.2800000000 	140201.2799998842
00000869a886d481 	391800.9500000000 	391800.9499997132 	140200.2200000000 	140200.2199997414
00000940f57099c6 	391800.8000000000 	391800.7999999741 	140200.6100000000 	140200.6099998080
0000096994118db6 	391800.9400000000 	391800.9399999789 	140200.6200000000 	140200.6199999148
00000992f42fd099 	391801.0200000000 	391801.0199997156 	140200.5100000000 	140200.5099998578
000009b05ea5da13 	391801.0800000000 	391801.0799999837 	140200.5100000000 	140200.5099998578
000009e22e6e6425 	391801.1100000000 	391801.1099999315 	140200.5900000000 	140200.5899999670
00000a4b0a0e7481 	391801.2500000000 	391801.2499999363 	140200.2200000000 	140200.2199997414
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.390623 0.000000 140200.000000 0.000000 0.390623
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libMorton2D.so.1.0.1 ~/Downloads/1?2?.las  76.83s user 7.47s system 156% cpu 53.825 total
```

### Trivial ###

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 5289 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 15692092 μs
x: 391800.0000000000 	392599.9900000000
y: 140200.0000000000 	140999.9900000000
samples: 35077820
[STXXL-ERRMSG] External memory block allocation error: 50331648 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 77902 μs
00000000008db92e 	391800.0000000000 	391800.0000000000 	140201.7300000000 	140201.7299998370
00000000010a3e4a 	391800.0000000000 	391800.0000000000 	140203.2500000000 	140203.2499998617
000000000248ea86 	391800.0000000000 	391800.0000000000 	140207.1400000000 	140207.1399999495
00000000040c4d0b 	391800.0000000000 	391800.0000000000 	140212.6500000000 	140212.6499999460
0000000004c642fd 	391800.0000000000 	391800.0000000000 	140214.9200000000 	140214.9199999388
000000000574c0e2 	391800.0000000000 	391800.0000000000 	140217.0500000000 	140217.0499998705
0000000005ceddd8 	391800.0000000000 	391800.0000000000 	140218.1500000000 	140218.1499998982
00000000060907cf 	391800.0000000000 	391800.0000000000 	140218.8600000000 	140218.8599998755
0000000007eab9e3 	391800.0000000000 	391800.0000000000 	140224.7400000000 	140224.7399998339
000000000ad1bff4 	391800.0000000000 	391800.0000000000 	140233.8100000000 	140233.8099999471
000000000b99a31a 	391800.0000000000 	391800.0000000000 	140236.2500000000 	140236.2499999476
000000000bcaca2c 	391800.0000000000 	391800.0000000000 	140236.8500000000 	140236.8499999965
000000000cecca47 	391800.0000000000 	391800.0000000000 	140240.3900000000 	140240.3899998385
000000000e000b77 	391800.0000000000 	391800.0000000000 	140243.7500000000 	140243.7499998147
000000000ea31150 	391800.0000000000 	391800.0000000000 	140245.7400000000 	140245.7399998716
00000000117b5875 	391800.0000000000 	391800.0000000000 	140254.6300000000 	140254.6299999329
0000000011c859ef 	391800.0000000000 	391800.0000000000 	140255.5700000000 	140255.5699999972
0000000012b6bdd1 	391800.0000000000 	391800.0000000000 	140258.4800000000 	140258.4799998435
0000000012bc79d8 	391800.0000000000 	391800.0000000000 	140258.5500000000 	140258.5499999672
00000000132a4008 	391800.0000000000 	391800.0000000000 	140259.8900000000 	140259.8899999400
0000000013327135 	391800.0000000000 	391800.0000000000 	140259.9900000000 	140259.9899998240
0000000013382d3c 	391800.0000000000 	391800.0000000000 	140260.0600000000 	140260.0599999477
00000000138bbc74 	391800.0000000000 	391800.0000000000 	140261.0800000000 	140261.0799999937
0000000013a6c524 	391800.0000000000 	391800.0000000000 	140261.4100000000 	140261.4099999647
00000000152485a5 	391800.0000000000 	391800.0000000000 	140266.0700000000 	140266.0699999229
0000000016227a2b 	391800.0000000000 	391800.0000000000 	140269.1700000000 	140269.1699998655
0000000016396a45 	391800.0000000000 	391800.0000000000 	140269.4500000000 	140269.4499999877
0000000016d0f811 	391800.0000000000 	391800.0000000000 	140271.3000000000 	140271.2999999835
00000000172cb876 	391800.0000000000 	391800.0000000000 	140272.4200000000 	140272.4199999135
00000000178aee03 	391800.0000000000 	391800.0000000000 	140273.5700000000 	140273.5699999763
00000000187af555 	391800.0000000000 	391800.0000000000 	140276.5000000000 	140276.4999999112
0000000018818313 	391800.0000000000 	391800.0000000000 	140276.5800000000 	140276.5799998929
0000000018fc64bf 	391800.0000000000 	391800.0000000000 	140278.0800000000 	140278.0799998291
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.195310 0.000000 140200.000000 0.000000 0.195310
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libTrivial2D.so.1.0.1 ~/Downloads/1421.las  24.46s user 3.73s system 165% cpu 17.075 total
```

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 10176 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 29040304 μs
x: 391800.0000000000 	392599.9900000000
y: 140200.0000000000 	141799.9900000000
samples: 65034704
[STXXL-ERRMSG] External memory block allocation error: 471859200 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 345222 μs
000000000046dc7a 	391800.0000000000 	391800.0000000000 	140201.7300000000 	140201.7299998463
0000000000851eee 	391800.0000000000 	391800.0000000000 	140203.2500000000 	140203.2499996855
00000000012474cb 	391800.0000000000 	391800.0000000000 	140207.1400000000 	140207.1399998718
00000000020625b1 	391800.0000000000 	391800.0000000000 	140212.6500000000 	140212.6499998475
0000000002632084 	391800.0000000000 	391800.0000000000 	140214.9200000000 	140214.9199998720
0000000002ba5f53 	391800.0000000000 	391800.0000000000 	140217.0500000000 	140217.0499998917
0000000002e76dbb 	391800.0000000000 	391800.0000000000 	140218.1500000000 	140218.1499997165
00000000030482ab 	391800.0000000000 	391800.0000000000 	140218.8600000000 	140218.8599998472
0000000003f55b52 	391800.0000000000 	391800.0000000000 	140224.7400000000 	140224.7399996759
000000000568ddc2 	391800.0000000000 	391800.0000000000 	140233.8100000000 	140233.8099996671
0000000005cccf2c 	391800.0000000000 	391800.0000000000 	140236.2500000000 	140236.2499996441
0000000005e562ab 	391800.0000000000 	391800.0000000000 	140236.8500000000 	140236.8499997179
000000000676627e 	391800.0000000000 	391800.0000000000 	140240.3900000000 	140240.3899998923
00000000070002dd 	391800.0000000000 	391800.0000000000 	140243.7500000000 	140243.7499996347
00000000075185a8 	391800.0000000000 	391800.0000000000 	140245.7400000000 	140245.7399996496
0000000008bda8a6 	391800.0000000000 	391800.0000000000 	140254.6300000000 	140254.6299999539
0000000008e42953 	391800.0000000000 	391800.0000000000 	140255.5700000000 	140255.5699999329
00000000095b5b13 	391800.0000000000 	391800.0000000000 	140258.4800000000 	140258.4799997132
00000000095e3915 	391800.0000000000 	391800.0000000000 	140258.5500000000 	140258.5499997156
0000000009951c17 	391800.0000000000 	391800.0000000000 	140259.8900000000 	140259.8899998679
00000000099934ac 	391800.0000000000 	391800.0000000000 	140259.9900000000 	140259.9899998181
00000000099c12ae 	391800.0000000000 	391800.0000000000 	140260.0600000000 	140260.0599998205
0000000009c5da39 	391800.0000000000 	391800.0000000000 	140261.0800000000 	140261.0799999086
0000000009d35e8b 	391800.0000000000 	391800.0000000000 	140261.4100000000 	140261.4099997070
000000000a923e7e 	391800.0000000000 	391800.0000000000 	140266.0700000000 	140266.0699999197
000000000b11388d 	391800.0000000000 	391800.0000000000 	140269.1700000000 	140269.1699998662
000000000b1cb095 	391800.0000000000 	391800.0000000000 	140269.4500000000 	140269.4499998757
000000000b68775c 	391800.0000000000 	391800.0000000000 	140271.3000000000 	140271.2999998858
000000000b96577c 	391800.0000000000 	391800.0000000000 	140272.4200000000 	140272.4199999242
000000000bc5722f 	391800.0000000000 	391800.0000000000 	140273.5700000000 	140273.5699999103
000000000c3d75a7 	391800.0000000000 	391800.0000000000 	140276.5000000000 	140276.4999999042
000000000c40bc84 	391800.0000000000 	391800.0000000000 	140276.5800000000 	140276.5799996408
000000000c7e2d41 	391800.0000000000 	391800.0000000000 	140278.0800000000 	140278.0799996390
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.195310 0.000000 140200.000000 0.000000 0.390623
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libTrivial2D.so.1.0.1 ~/Downloads/142?.las  45.81s user 5.17s system 166% cpu 30.596 total
```

```
[STXXL-MSG] STXXL v1.4.99 (prerelease/Release) (git 0a80a8c55993948f7f2f6c2c5a51ff45b403045b) + gnu parallel(20170502)
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
bounding box: 12452 μs
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-MSG] open() error on path=/tmp/StreetLevel.stxxl flags=16450, retrying without O_DIRECT.
[STXXL-MSG] Disk '/tmp/StreetLevel.stxxl' is allocated, space: 0 MiB, I/O implementation: syscall delete_on_exit queue=0 devid=0 unlink_on_open
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
(readers.las Error) GDAL failure (6) No translation for Lambert_Conformal_Conic to PROJ.4 format is known.
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
[STXXL-ERRMSG] External memory block allocation error: 536870912 bytes requested, 0 bytes free. Trying to extend the external memory space...
input: 44466970 μs
x: 391800.0000000000 	393399.9900000000
y: 140200.0000000000 	141799.9900000000
samples: 97901076
[STXXL-ERRMSG] External memory block allocation error: 448790528 bytes requested, 0 bytes free. Trying to extend the external memory space...
sort: 295501 μs
000000000046dc7a 	391800.0000000000 	391800.0000000000 	140201.7300000000 	140201.7299998463
0000000000851eee 	391800.0000000000 	391800.0000000000 	140203.2500000000 	140203.2499996855
00000000012474cb 	391800.0000000000 	391800.0000000000 	140207.1400000000 	140207.1399998718
00000000020625b1 	391800.0000000000 	391800.0000000000 	140212.6500000000 	140212.6499998475
0000000002632084 	391800.0000000000 	391800.0000000000 	140214.9200000000 	140214.9199998720
0000000002ba5f53 	391800.0000000000 	391800.0000000000 	140217.0500000000 	140217.0499998917
0000000002e76dbb 	391800.0000000000 	391800.0000000000 	140218.1500000000 	140218.1499997165
00000000030482ab 	391800.0000000000 	391800.0000000000 	140218.8600000000 	140218.8599998472
0000000003f55b52 	391800.0000000000 	391800.0000000000 	140224.7400000000 	140224.7399996759
000000000568ddc2 	391800.0000000000 	391800.0000000000 	140233.8100000000 	140233.8099996671
0000000005cccf2c 	391800.0000000000 	391800.0000000000 	140236.2500000000 	140236.2499996441
0000000005e562ab 	391800.0000000000 	391800.0000000000 	140236.8500000000 	140236.8499997179
000000000676627e 	391800.0000000000 	391800.0000000000 	140240.3900000000 	140240.3899998923
00000000070002dd 	391800.0000000000 	391800.0000000000 	140243.7500000000 	140243.7499996347
00000000075185a8 	391800.0000000000 	391800.0000000000 	140245.7400000000 	140245.7399996496
0000000008bda8a6 	391800.0000000000 	391800.0000000000 	140254.6300000000 	140254.6299999539
0000000008e42953 	391800.0000000000 	391800.0000000000 	140255.5700000000 	140255.5699999329
00000000095b5b13 	391800.0000000000 	391800.0000000000 	140258.4800000000 	140258.4799997132
00000000095e3915 	391800.0000000000 	391800.0000000000 	140258.5500000000 	140258.5499997156
0000000009951c17 	391800.0000000000 	391800.0000000000 	140259.8900000000 	140259.8899998679
00000000099934ac 	391800.0000000000 	391800.0000000000 	140259.9900000000 	140259.9899998181
00000000099c12ae 	391800.0000000000 	391800.0000000000 	140260.0600000000 	140260.0599998205
0000000009c5da39 	391800.0000000000 	391800.0000000000 	140261.0800000000 	140261.0799999086
0000000009d35e8b 	391800.0000000000 	391800.0000000000 	140261.4100000000 	140261.4099997070
000000000a923e7e 	391800.0000000000 	391800.0000000000 	140266.0700000000 	140266.0699999197
000000000b11388d 	391800.0000000000 	391800.0000000000 	140269.1700000000 	140269.1699998662
000000000b1cb095 	391800.0000000000 	391800.0000000000 	140269.4500000000 	140269.4499998757
000000000b68775c 	391800.0000000000 	391800.0000000000 	140271.3000000000 	140271.2999998858
000000000b96577c 	391800.0000000000 	391800.0000000000 	140272.4200000000 	140272.4199999242
000000000bc5722f 	391800.0000000000 	391800.0000000000 	140273.5700000000 	140273.5699999103
000000000c3d75a7 	391800.0000000000 	391800.0000000000 	140276.5000000000 	140276.4999999042
000000000c40bc84 	391800.0000000000 	391800.0000000000 	140276.5800000000 	140276.5799996408
000000000c7e2d41 	391800.0000000000 	391800.0000000000 	140278.0800000000 	140278.0799996390
wkt = PROJCS["NAD_1983_StatePlane_Maryland_FIPS_1900",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137,298.257222101004]],PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]], PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",400000],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",-77],PARAMETER["Standard_Parallel_1",38.3],PARAMETER["Standard_Parallel_2",39.45],PARAMETER["Latitude_Of_Origin",37.6666666666667],UNIT["Meter",1]]
transform = 391800.000000 0.390623 0.000000 140200.000000 0.000000 0.390623
[STXXL-ERRMSG] Removing disk file: /tmp/StreetLevel.stxxl
dem_test ./curve/libTrivial2D.so.1.0.1 ~/Downloads/1?2?.las  68.96s user 7.01s system 164% cpu 46.057 total
```